### PR TITLE
getproject and getsubproject now take projecid as parameter.

### DIFF
--- a/src/main/java/dev/examproject/controller/WebController.java
+++ b/src/main/java/dev/examproject/controller/WebController.java
@@ -103,7 +103,7 @@ public class WebController {
         User authenticatedUser = (User) session.getAttribute("user");
         Project selectedProject = (Project) session.getAttribute("selectedProject");
         if (selectedProject != null) {
-            Project project = projectService.getProject(selectedProject.getName());
+            Project project = projectService.getProject(selectedProject.getProjectId());
          //   List<Task> tasks = taskService.getProjectTasks(selectedProject.getProjectId());
             List<Project> subProjects = projectService.getSubProjectsForProject(selectedProject.getProjectId());
 
@@ -171,11 +171,11 @@ public class WebController {
         return "redirect:/login";
     }
 
-    @GetMapping(path = "/selectProject/{projectName}")
-    public String selectProject(@PathVariable("projectName") String projectName, HttpSession session) {
+    @GetMapping(path = "/selectProject/{projectId}")
+    public String selectProject(@PathVariable("projectId") int projectId, HttpSession session) {
         User authenticatedUser = (User) session.getAttribute("user");
         if (authenticatedUser != null) {
-            Project project = projectService.getProject(projectName);
+            Project project = projectService.getProject(projectId);
             session.setAttribute("selectedProject", project);
             return "redirect:/" + authenticatedUser.getUsername() + "/overview";
         }
@@ -256,11 +256,11 @@ public class WebController {
         }
         return "redirect:/login";
     }
-    @GetMapping(path = "/selectSubProject/{subProjectName}")
-    public String selectSubProject(@PathVariable("subProjectName") String subProjectName, HttpSession session) {
+    @GetMapping(path = "/selectSubProject/{projectId}")
+    public String selectSubProject(@PathVariable("projectId") int projectId, HttpSession session) {
         User authenticatedUser = (User) session.getAttribute("user");
         if (authenticatedUser != null) {
-            Project subProject = projectService.getSubProject(subProjectName);
+            Project subProject = projectService.getSubProject(projectId);
             session.setAttribute("selectedSubProject", subProject);
             return "redirect:/subProjectOverview";
         }

--- a/src/main/java/dev/examproject/repository/ProjectRepository.java
+++ b/src/main/java/dev/examproject/repository/ProjectRepository.java
@@ -110,22 +110,20 @@ public class ProjectRepository {
         return null;
     }
 
-    public Project getProject(String name) {
+    public Project getProject(int projectId) {
         Connection conn = ConnectionManager.getConnection(dbUrl, dbUsername, dbPassword);
-        String sql = "SELECT PROJECTS.*, project_users.is_admin FROM PROJECTS " +
-                "JOIN project_users ON PROJECTS.id = project_users.project_id " +
-                "WHERE PROJECTS.name = ? ";
+        String sql = "SELECT * FROM PROJECTS WHERE id = ?";
         try (PreparedStatement ps = conn.prepareStatement(sql)) {
-            ps.setString(1, name);
+            ps.setInt(1, projectId);
             ResultSet rs = ps.executeQuery();
             if (rs.next()) {
                 Project project = new Project(rs.getInt("id"), rs.getString("name"), rs.getString("description"));
-                project.setAdmin(getAdminForProject(getId(name))); // det her er pis, find en løsning
+                project.setAdmin(getAdminForProject(projectId));
                 project.setAssignedUsers(getAssignedUsers(rs.getInt("id")));
                 return project;
             }
         } catch (SQLException e) {
-            logger.error("Error getting project: " + name, e);
+            logger.error("Error getting project: " + projectId, e);
         }
         return null;
     }
@@ -193,11 +191,11 @@ public class ProjectRepository {
         }
         return null;
     }
-    public Project getSubProject(String subProjectName) {
+    public Project getSubProject(int projectId) {
         Connection conn = ConnectionManager.getConnection(dbUrl, dbUsername, dbPassword);
-        String sql = "SELECT * FROM projects WHERE name = ?";
+        String sql = "SELECT * FROM projects WHERE id = ?";
         try (PreparedStatement ps = conn.prepareStatement(sql)) {
-            ps.setString(1, subProjectName);
+            ps.setInt(1, projectId);
             ResultSet rs = ps.executeQuery();
             if (rs.next()) {
                 Project project = new Project(rs.getInt("id"), rs.getString("name"), rs.getString("description"));
@@ -206,7 +204,7 @@ public class ProjectRepository {
                 return project;
             }
         } catch (SQLException e) {
-            logger.error("Error getting sub-project with name: " + subProjectName, e);
+            logger.error("Error getting sub-project with ID: " + projectId, e);
         }
         return null;
     }

--- a/src/main/java/dev/examproject/service/ProjectService.java
+++ b/src/main/java/dev/examproject/service/ProjectService.java
@@ -28,8 +28,8 @@ public class ProjectService {
         return repository.getId(projectName);
     }
 
-    public Project getProject(String projectName) {
-        return repository.getProject(projectName);
+    public Project getProject(int projectid) {
+        return repository.getProject(projectid);
     }
 
     public List<Project> getProjectsForUser(int userId, String username) {
@@ -38,8 +38,8 @@ public class ProjectService {
     public List<Project> getSubProjectsForProject(int projectId) {
         return repository.getSubProjectsForProject(projectId);
     }
-    public Project getSubProject(String subProjectName) {
-        return repository.getSubProject(subProjectName);
+    public Project getSubProject(int projectId) {
+        return repository.getSubProject(projectId);
     }
 
     public int getTotalRequiredHoursForAllSubProjects(int parentProjectId) {

--- a/src/main/resources/templates/overview.html
+++ b/src/main/resources/templates/overview.html
@@ -72,7 +72,7 @@
             <ul>
                 <li th:each="user : ${subProject.assignedUsers}" th:text="${user}"></li>
             </ul>
-            <a th:href="@{'/selectSubProject/' + ${subProject.name}}" class="btn btn-primary">Select</a>
+            <a th:href="@{'/selectSubProject/' + ${subProject.projectId}}" class="btn btn-primary">Select</a>
         </li>
     </ul>
     <!-- Form code remains the same -->

--- a/src/main/resources/templates/projects.html
+++ b/src/main/resources/templates/projects.html
@@ -53,7 +53,7 @@
             <ul>
                 <li th:each="user : ${project.assignedUsers}" th:text="${user.username}"></li>
             </ul>
-            <a class="btn btn-primary" th:href="@{'/selectProject/' + ${project.name}}">Select</a>
+            <a class="btn btn-primary" th:href="@{'/selectProject/' + ${project.projectId}}">Select</a>
         </li>
     </ul>
 </div>

--- a/src/main/resources/templates/subProjectOverview.html
+++ b/src/main/resources/templates/subProjectOverview.html
@@ -64,6 +64,7 @@
             <span th:text="'Required Hours: ' + ${task.requiredHours}"></span>
         </li>
     </ul>
+    <a class="btn btn-primary" th:href="@{'/' + ${user.username} + '/overview'}">Return to Overview</a>
 </div>
 
 <div class="container" th:unless="${selectedSubProject != null}">

--- a/src/test/java/dev/examproject/ProjectRepositoryTest.java
+++ b/src/test/java/dev/examproject/ProjectRepositoryTest.java
@@ -49,8 +49,8 @@ public class ProjectRepositoryTest {
     @Test
     void getProject() {
         // Test that the repository returns the correct project
-        Project expected = repository.getProject("test 1");
-        assertEquals("test 1", expected.getName());
+        Project expected = repository.getProject(1);
+        assertEquals(1, expected.getProjectId());
     }
 
     // skal skrives om senere, magter ikke lige nu


### PR DESCRIPTION
Changed the getproject and getsubproject method to take projectid as a parameter. This has fixed an issue where project with the same name would automatically, get the same subprojects and tasks.